### PR TITLE
fix: update babel.config.js for ESM error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "name": "create-ks-project",
   "version": "0.0.22",
-  "main": "index.js",
-  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/kubesphere/create-ks-project"
   },
+  "license": "MIT",
+  "main": "index.js",
   "bin": {
     "create-ks-project": "./dist/index.js"
   },
   "files": ["dist"],
   "scripts": {
     "dev": "ncc build ./index.ts -w -o dist/",
+    "prepublish": "yarn release",
     "prerelease": "rimraf ./dist/",
-    "release": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
-    "prepublish": "yarn release"
+    "release": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register"
   },
   "dependencies": {
     "@types/node": "^12.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ks-project",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/kubesphere/create-ks-project"
@@ -10,7 +10,9 @@
   "bin": {
     "create-ks-project": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "ncc build ./index.ts -w -o dist/",
     "prepublish": "yarn release",

--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  sourceType: 'unambiguous',
   presets: [
     [
       '@babel/preset-env',
@@ -10,7 +11,7 @@ module.exports = {
   ],
   plugins: [
     '@babel/plugin-transform-runtime',
-    'lodash',
+    // 'lodash',
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-syntax-import-meta',
     ['@babel/plugin-proposal-decorators', { legacy: true }],

--- a/template/package.json
+++ b/template/package.json
@@ -136,9 +136,9 @@
     "yargs": "^17.0.1"
   },
   "dependencies": {
-    "@ks-console/bootstrap": "^0.0.1",
+    "@ks-console/bootstrap": "^0.0.2",
     "@ks-console/server": "^0.0.1",
-    "@ks-console/shared": "0.0.1",
+    "@ks-console/shared": "0.0.2",
     "@kubed/charts": "^0.0.14",
     "@kubed/code-editor": "^0.0.20",
     "@kubed/components": "^0.0.81",

--- a/template/package.json
+++ b/template/package.json
@@ -136,9 +136,9 @@
     "yargs": "^17.0.1"
   },
   "dependencies": {
-    "@ks-console/bootstrap": "^0.0.2",
+    "@ks-console/bootstrap": "^0.0.3",
     "@ks-console/server": "^0.0.1",
-    "@ks-console/shared": "0.0.2",
+    "@ks-console/shared": "0.0.3",
     "@kubed/charts": "^0.0.14",
     "@kubed/code-editor": "^0.0.20",
     "@kubed/components": "^0.0.81",

--- a/template/package.json
+++ b/template/package.json
@@ -2,23 +2,32 @@
   "name": "kubesphere-extensions",
   "version": "1.0.0",
   "private": true,
-  "main": "index.js",
   "license": "MIT",
+  "main": "index.js",
   "workspaces": ["extensions/*"],
   "scripts": {
+    "build:dll": "ksc build:dll",
+    "build:ext": "ksc build:ext",
+    "build:prod": "ksc build:prod",
+    "create:ext": "ksc create:ext",
+    "dev": "concurrently -k --raw 'yarn dev:client' 'yarn dev:server'",
     "dev:client": "ksc dev -u true",
     "dev:server": "ksc-server",
-    "dev": "concurrently -k --raw 'yarn dev:client' 'yarn dev:server'",
-    "start": "NODE_ENV=production ksc-server",
-    "build:dll": "ksc build:dll",
-    "build:prod": "ksc build:prod",
-    "build:ext": "ksc build:ext",
-    "create:ext": "ksc create:ext"
+    "start": "NODE_ENV=production ksc-server"
   },
   "browserslist": ["> 1%", "last 2 versions", "not ie <= 8"],
-  "engines": {
-    "node": ">= 6.0.0",
-    "npm": ">= 3.0.0"
+  "dependencies": {
+    "@ks-console/bootstrap": "^0.0.5",
+    "@ks-console/server": "^0.0.1",
+    "@ks-console/shared": "0.0.4",
+    "@kubed/charts": "^0.0.14",
+    "@kubed/code-editor": "^0.0.20",
+    "@kubed/components": "^0.0.81",
+    "@kubed/diff-viewer": "^0.0.15",
+    "@kubed/hooks": "^0.0.14",
+    "@kubed/icons": "^0.0.13",
+    "@kubed/log-viewer": "^0.0.14",
+    "@kubed/stook": "^0.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.7",
@@ -135,17 +144,8 @@
     "webpackbar": "^5.0.0-3",
     "yargs": "^17.0.1"
   },
-  "dependencies": {
-    "@ks-console/bootstrap": "^0.0.5",
-    "@ks-console/server": "^0.0.1",
-    "@ks-console/shared": "0.0.4",
-    "@kubed/charts": "^0.0.14",
-    "@kubed/code-editor": "^0.0.20",
-    "@kubed/components": "^0.0.81",
-    "@kubed/diff-viewer": "^0.0.15",
-    "@kubed/hooks": "^0.0.14",
-    "@kubed/icons": "^0.0.13",
-    "@kubed/log-viewer": "^0.0.14",
-    "@kubed/stook": "^0.0.4"
+  "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -136,9 +136,9 @@
     "yargs": "^17.0.1"
   },
   "dependencies": {
-    "@ks-console/bootstrap": "^0.0.3",
+    "@ks-console/bootstrap": "^0.0.5",
     "@ks-console/server": "^0.0.1",
-    "@ks-console/shared": "0.0.3",
+    "@ks-console/shared": "0.0.4",
     "@kubed/charts": "^0.0.14",
     "@kubed/code-editor": "^0.0.20",
     "@kubed/components": "^0.0.81",


### PR DESCRIPTION
fixed error when extension load:

`ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: NUMBER`

https://github.com/babel/babel/issues/12731